### PR TITLE
Remove JS static analysis from distinctions

### DIFF
--- a/config/parameters/plan-distinctions.yaml
+++ b/config/parameters/plan-distinctions.yaml
@@ -59,10 +59,6 @@ parameters:
           name:
             primary: "CSS validation"
           icon: dot-circle-o
-        js_static_analysis:
-          name:
-            primary: "JS static analysis"
-          icon: dot-circle-o
         link_integrity_checking:
           name:
             primary: "Link integrity checking"

--- a/templates/Partials/account-benefits/test-types.html.twig
+++ b/templates/Partials/account-benefits/test-types.html.twig
@@ -20,14 +20,6 @@
     <li class="distinction-data-item">
         {% include 'Partials/boolean-icon.html.twig'
             with {
-                'is_set': plan_distinctions.js_static_analysis.value,
-                'name':category.distinctions.js_static_analysis.name.primary
-            }
-        %}
-    </li>
-    <li class="distinction-data-item">
-        {% include 'Partials/boolean-icon.html.twig'
-            with {
                 'is_set': plan_distinctions.link_integrity_checking.value,
                 'name':category.distinctions.link_integrity_checking.name.primary
             }


### PR DESCRIPTION
Fixes #139